### PR TITLE
Expense Form

### DIFF
--- a/app/src/main/java/com/example/wokolskidashboard/ui/components/ExpenseForm.kt
+++ b/app/src/main/java/com/example/wokolskidashboard/ui/components/ExpenseForm.kt
@@ -18,6 +18,7 @@ fun ExpenseForm(
     onCategoryChange: (String) -> Unit,
     onUnnecessaryChange: (Boolean) -> Unit,
 
+    onAddExpense: () -> Unit
 ) {
     Column(
         modifier = Modifier
@@ -61,6 +62,12 @@ fun ExpenseForm(
                 checked = isUnnecessary,
                 onCheckedChange = onUnnecessaryChange
             )
+        }
+        Button(
+            onClick = onAddExpense,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text("Zapisz wydatek")
         }
     }
 }

--- a/app/src/main/java/com/example/wokolskidashboard/ui/components/ExpenseForm.kt
+++ b/app/src/main/java/com/example/wokolskidashboard/ui/components/ExpenseForm.kt
@@ -8,7 +8,9 @@ import androidx.compose.ui.unit.dp
 
 @Composable
 fun ExpenseForm(
-
+    name: String,
+    amount: String,
+    category: String,
 ) {
     Column(
         modifier = Modifier

--- a/app/src/main/java/com/example/wokolskidashboard/ui/components/ExpenseForm.kt
+++ b/app/src/main/java/com/example/wokolskidashboard/ui/components/ExpenseForm.kt
@@ -11,6 +11,9 @@ fun ExpenseForm(
     name: String,
     amount: String,
     category: String,
+    isUnnecessary: Boolean,
+
+    onUnnecessaryChange: (Boolean) -> Unit,
 ) {
     Column(
         modifier = Modifier
@@ -23,5 +26,16 @@ fun ExpenseForm(
             text = "💸 Wydatki Wokulskiego",
             style = MaterialTheme.typography.titleMedium
         )
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Text("Wydatek zbyteczny")
+            Switch(
+                checked = isUnnecessary,
+                onCheckedChange = onUnnecessaryChange
+            )
+        }
     }
 }

--- a/app/src/main/java/com/example/wokolskidashboard/ui/components/ExpenseForm.kt
+++ b/app/src/main/java/com/example/wokolskidashboard/ui/components/ExpenseForm.kt
@@ -1,2 +1,25 @@
 package com.example.wokolskidashboard.ui.components
 
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun ExpenseForm(
+
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+
+        Text(
+            text = "💸 Wydatki Wokulskiego",
+            style = MaterialTheme.typography.titleMedium
+        )
+    }
+}

--- a/app/src/main/java/com/example/wokolskidashboard/ui/components/ExpenseForm.kt
+++ b/app/src/main/java/com/example/wokolskidashboard/ui/components/ExpenseForm.kt
@@ -13,7 +13,11 @@ fun ExpenseForm(
     category: String,
     isUnnecessary: Boolean,
 
+    onNameChange: (String) -> Unit,
+    onAmountChange: (String) -> Unit,
+    onCategoryChange: (String) -> Unit,
     onUnnecessaryChange: (Boolean) -> Unit,
+
 ) {
     Column(
         modifier = Modifier
@@ -25,6 +29,27 @@ fun ExpenseForm(
         Text(
             text = "💸 Wydatki Wokulskiego",
             style = MaterialTheme.typography.titleMedium
+        )
+
+        OutlinedTextField(
+            value = name,
+            onValueChange = onNameChange,
+            label = { Text("Cel wydatku") },
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        OutlinedTextField(
+            value = amount,
+            onValueChange = onAmountChange,
+            label = { Text("Kwota (Rubel)") },
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        OutlinedTextField(
+            value = category,
+            onValueChange = onCategoryChange,
+            label = { Text("Kategoria (np. Sklep, Osobiste)") },
+            modifier = Modifier.fillMaxWidth()
         )
 
         Row(


### PR DESCRIPTION
Dodano komponent ExpenseForm umożliwiający wprowadzanie wydatków (nazwa, kwota, kategoria, switch “zbyteczny”) z wykorzystaniem state hoisting i callbacków do integracji z MainScreen.